### PR TITLE
Minimap availability check

### DIFF
--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -484,7 +484,10 @@ function module:SetMinimap()
 	
 	m_coord:SetScript("OnUpdate", function(_)
 		--local x,y = GetPlayerMapPosition("player")
-		local x, y = C_Map.GetPlayerMapPosition( C_Map.GetBestMapForUnit("player"), "player" ):GetXY()
+		local m = C_Map.GetPlayerMapPosition( C_Map.GetBestMapForUnit("player"), "player" )
+                        if m then
+                                local x,y = m:GetXY()
+                        end
 		if not x then
 			m_coord_text:SetText("")
 		else


### PR DESCRIPTION
The change fixes the minimap error because the map might be not available at the time, so you must check for it first.